### PR TITLE
Update tutorial step to go to barren patch instead of barren field

### DIFF
--- a/src/commonMain/kotlin/resources/storyEvents/Tutorial.kt
+++ b/src/commonMain/kotlin/resources/storyEvents/Tutorial.kt
@@ -82,10 +82,10 @@ class Tutorial : StoryEventResource {
             )
         ),
 
-        StoryEvent("Tutorial", 90, "I should travel to Barren Field.",
+        StoryEvent("Tutorial", 90, "I should travel to Barren Patch.",
             ConditionalEvents(InteractEvent::class,
                 { event, _ -> event.creature.isPlayer() && event.interactionTarget.name == "Apple Pie Recipe" },
-                { event, _ -> listOfNotNull(eventWithPlayer(event.creature) { MessageEvent(it, "Once I'm done here I should travel to Barren Field.") }) }
+                { event, _ -> listOfNotNull(eventWithPlayer(event.creature) { MessageEvent(it, "Once I'm done here I should travel to Barren Patch.") }) }
             )
         ),
 


### PR DESCRIPTION
Updated tutorial text that says "I should go to Barren Field" to say barren patch since barren field doesn't exist. If this is intentional, please ignore this PR.